### PR TITLE
Clang version is now set in dockerfile.common

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,9 +6,6 @@ VOLUME /service
 WORKDIR /service
 
 CMD cd build && \
-  cp /home/ubuntu/IncludeOS_install/chainloader /service/build/chainloader && \
-  export INCLUDEOS_PREFIX=/home/ubuntu/IncludeOS_install && \
-  export CC=clang-3.8 && \
-  export CXX=clang++-3.8 && \
+  cp $(find ~/IncludeOS_install -name chainloader) /service/build/chainloader && \
   cmake .. && \
   make

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -36,3 +36,6 @@ RUN cd ~ && pwd && \
 RUN cd ~ && pwd && \
   cd IncludeOS && \
   ./install.sh -n
+
+COPY entrypoint.sh .
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+pushd ~/IncludeOS/etc/ > /dev/null
+if version=$(grep -oP 'CLANG_VERSION_MIN_REQUIRED="\K[^"]+' install_dependencies_linux.sh); then :
+elif version=$(grep -oP 'CLANG_VERSION="\K[^"]+' install_dependencies_linux.sh); then :
+else version=3.8
+fi
+export CC=clang-$version
+export CXX=clang++-$version
+popd > /dev/null
+
+exec "$@"


### PR DESCRIPTION
Looks for specific string in `install_dependencies_linux.sh`. As this has changed multiple times I've had to put in multiple checks, with a fallback on later versions to clang-3.8. 